### PR TITLE
Fix version pinning issue

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -454,7 +454,7 @@ preseq=3.2.0,samtools=1.17,csvtk=0.25.0
 bedtools=2.31.0,samtools=1.17,ucsc-bedgraphtobigwig=377
 bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
-perl=5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
+perl==5.26.2,perl-sort-key==1.33,perl-yaml-libyaml==0.88
 tophat=2.1.1,samtools=1.17
 perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=3.4
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -454,11 +454,11 @@ preseq=3.2.0,samtools=1.17,csvtk=0.25.0
 bedtools=2.31.0,samtools=1.17,ucsc-bedgraphtobigwig=377
 bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
-perl==5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
+perl=5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
 tophat=2.1.1,samtools=1.17
-perl==5.26.2,r==3.6.0,bcftools==1.13,bedtools==2.30.0,bc==1.07.1,grep==3.4
-python==3.7.9,pandas==1.3.4,numpy==1.21.4,pyranges==0.0.115,fire==0.4.0
-python==3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam==0.15.4,htslib==1.9
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=3.4
+python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
+python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16
 umi-transfer=1.0.0

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -456,7 +456,7 @@ bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
 perl==5.26.2,perl-sort-key==1.33,perl-yaml-libyaml==0.88
 tophat=2.1.1,samtools=1.17
-perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=3.4
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=2
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
 python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -454,7 +454,7 @@ preseq=3.2.0,samtools=1.17,csvtk=0.25.0
 bedtools=2.31.0,samtools=1.17,ucsc-bedgraphtobigwig=377
 bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
-perl==5.26.2,perl-sort-key==1.33,perl-yaml-libyaml==0.88
+perl==5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
 tophat=2.1.1,samtools=1.17
 perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=3	quay.io/condaforge/mambaforge:4.9.2-7	0
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -456,7 +456,7 @@ bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
 perl==5.26.2,perl-sort-key==1.33,perl-yaml-libyaml==0.88
 tophat=2.1.1,samtools=1.17
-perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=2
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep=3	quay.io/condaforge/mambaforge:4.9.2-7	0
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
 python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16


### PR DESCRIPTION
Mulled containers created via https://github.com/BioContainers/multi-package-containers/pull/2739 did not have expected tool versions (see #3). Debugging pointed that use of version pinning when using `==` instead of `=` causes the issue. Not sure why this is the case. This PR modifies to use `=` for pinning instead.

Additionally, `grep` is added to one of them along with the base image. Previous container's grep is not GNU and instead it is from BusyBox. It caused issues when using the container.
